### PR TITLE
Vagrantfile and plain provisioning script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 before_install:
-  - sudo apt-get install virtualbox-4.2
-#  - sudo apt-get install linux-headers-$(uname -r)
-#  - sudo dpkg-reconfigure virtualbox-dkms
-  - sudo apt-get install -r vagrant
+  - sudo apt-get install virtualbox
+  - sudo apt-get install build-essential linux-headers-`uname -r`
+  - sudo dpkg-reconfigure virtualbox-dkms
+  - sudo apt-get remove virtualbox && sudo apt-get install virtualbox
+  - sudo apt-get install vagrant
 
 bundler_args: ''
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 before_install:
-  - apt-get install virtualbox
-  - apt-get install vagrant
+  - sudo apt-get install virtualbox
+  - sudo apt-get install vagrant
 bundler_args: ''
 script:
   - vagrant box add hashicorp/precise32

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 before_install:
   - sudo apt-get install virtualbox
-  - sudo apt-get install build-essential linux-headers-`uname -r`
+  - sudo apt-get install build-essential linux-headers-3.8.0-32-generic
   - sudo dpkg-reconfigure virtualbox-dkms
   - sudo apt-get remove virtualbox && sudo apt-get install virtualbox
   - sudo apt-get install vagrant

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
 before_install:
   - sudo apt-get install virtualbox
   - sudo apt-get install vagrant
+  - sudo apt-get install linux-headers-$(uname -r)
+  - sudo dpkg-reconfigure virtualbox-dkms
 bundler_args: ''
 script:
-  - vagrant box add hashicorp/precise32
-  - vagrant up
-  - vagrant halt
-  - vagrant destroy
+  - sudo vagrant box add hashicorp/precise32
+  - sudo vagrant up
+  - sudo vagrant halt
+  - sudo vagrant destroy

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,13 @@
 before_install:
-  - sudo apt-get install virtualbox
-  - sudo apt-get install vagrant
-  - sudo apt-get install linux-headers-$(uname -r)
-  - sudo dpkg-reconfigure virtualbox-dkms
+  - sudo apt-get install virtualbox-4.2
+#  - sudo apt-get install linux-headers-$(uname -r)
+#  - sudo dpkg-reconfigure virtualbox-dkms
+  - sudo apt-get install -r vagrant
+
 bundler_args: ''
 script:
-  - sudo vagrant box add hashicorp/precise32
-  - sudo vagrant up
-  - sudo vagrant halt
-  - sudo vagrant destroy
+  - which vagrant
+  - vagrant box add hashicorp/precise32
+  - vagrant up
+  - vagrant halt
+  - vagrant destroy

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+before_install:
+  - apt-get install virtualbox
+  - apt-get install vagrant
+bundler_args: ''
+script:
+  - vagrant box add hashicorp/precise32
+  - vagrant up
+  - vagrant halt
+  - vagrant destroy

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,16 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.vm.box = "hashicorp/precise32"
+  config.vm.provision "shell", path: "./vm-setup/configure-vagrant-0.10.3.sh"
+  config.vm.network :forwarded_port, host: 3333, guest: 3000
+  config.vm.synced_folder ".", "/courseware"
+  config.vm.provider "virtualbox" do |v|
+    # Set as appropriate, can alter in VirtualBox Manager when shutdown
+    v.memory = 1024
+    v.cpus = 1
+  end
+end

--- a/vm-setup/configure-vagrant-0.10.3.sh
+++ b/vm-setup/configure-vagrant-0.10.3.sh
@@ -2,20 +2,13 @@
 # Simple autograder setup.sh run by Vagrant
 
 apt-get install -y curl
-
 \curl -L https://get.rvm.io | bash -s stable  --ruby=1.9.3
-
 #rvm command output says to do this.
 usermod -a -G rvm vagrant
 #rvm command output says to do this too.
 source /etc/profile.d/rvm.sh
 rvm requirements
 rvm reload
-
-#rvm rubygems specific version?
-
-wget -qO- https://toolbelt.heroku.com/install-ubuntu.sh | sh
-
 # remove warning when having ruby version in Gemfile so Heroku uses correct version
 rvm rvmrc warning ignore allGemfiles
 
@@ -30,24 +23,9 @@ add-apt-repository ppa:chris-lea/node.js
 apt-get update
 apt-get -qq install -y nodejs
 
-# Install jslint
-cd ~/
-curl -LO http://www.javascriptlint.com/download/jsl-0.3.0-src.tar.gz
-tar -zxf jsl-0.3.0-src.tar.gz
-cd jsl-0.3.0/src/
-make -s -f Makefile.ref
-cd ~/
-cp jsl-0.3.0/src/Linux_All_DBG.OBJ/jsl /usr/local/bin
-rm jsl-0.3.0-src.tar.gz
-rm -rf ~/jsl-0.3.0
+wget -qO- https://toolbelt.heroku.com/install-ubuntu.sh | sh
+gem install rails '3.2.15'
 
-# Install other programs
-apt-get install -qq git
-apt-get -qq install graphviz
-apt-get -qq install libpq-dev
-
-#gem install cucumber
-#gem install rspec
 # top-level dir is specified in Vagrantfile as config.vm.synced_folder
 cd /courseware/vm-setup/rottenpotatoes
 #bundle update --source debugger # should update the Gemfile.lock
@@ -78,4 +56,5 @@ echo "
   'source ~/.profile', or reopen Terminals.
 
 * Install finished. Do 'vagrant ssh' to get into this box, 'vagrant halt' to stop it.
+
 "

--- a/vm-setup/configure-vagrant-0.10.3.sh
+++ b/vm-setup/configure-vagrant-0.10.3.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# Simple autograder setup.sh run by Vagrant
+
+apt-get install -y curl
+
+\curl -L https://get.rvm.io | bash -s stable  --ruby=1.9.3
+
+#rvm command output says to do this.
+usermod -a -G rvm vagrant
+#rvm command output says to do this too.
+source /etc/profile.d/rvm.sh
+rvm requirements
+rvm reload
+
+#rvm rubygems specific version?
+
+wget -qO- https://toolbelt.heroku.com/install-ubuntu.sh | sh
+
+# remove warning when having ruby version in Gemfile so Heroku uses correct version
+rvm rvmrc warning ignore allGemfiles
+
+# Install sqlite3 dev
+apt-get -qq install sqlite3 libsqlite3-dev
+# Install required libs and optional feedvalidator for typo homework
+apt-get -qq install libxml2-dev libxslt-dev
+apt-get -qq install python-feedvalidator
+
+# Install nodejs
+add-apt-repository ppa:chris-lea/node.js
+apt-get update
+apt-get -qq install -y nodejs
+
+# Install jslint
+cd ~/
+curl -LO http://www.javascriptlint.com/download/jsl-0.3.0-src.tar.gz
+tar -zxf jsl-0.3.0-src.tar.gz
+cd jsl-0.3.0/src/
+make -s -f Makefile.ref
+cd ~/
+cp jsl-0.3.0/src/Linux_All_DBG.OBJ/jsl /usr/local/bin
+rm jsl-0.3.0-src.tar.gz
+rm -rf ~/jsl-0.3.0
+
+# Install other programs
+apt-get install -qq git
+apt-get -qq install graphviz
+apt-get -qq install libpq-dev
+
+#gem install cucumber
+#gem install rspec
+# top-level dir is specified in Vagrantfile as config.vm.synced_folder
+cd /courseware/vm-setup/rottenpotatoes
+#bundle update --source debugger # should update the Gemfile.lock
+bundle install
+bundle exec rake db:create
+bundle exec rake db:migrate
+bundle exec rake db:test:prepare
+bundle exec rake db:seed
+
+
+echo "
+Done.
+############### Post-install  ###############
+
+* Make the terminal prompt display current git branch:
+  Make a backup of your ~/.profile and add this at the end.
+  You can uncomment the other states if interested.
+
+# Dirty => *, Untracked => %, Stash => $
+GIT_PS1_SHOWDIRTYSTATE=1
+# GIT_PS1_SHOWUNTRACKEDFILES=1
+# GIT_PS1_SHOWSTASHSTATE=1
+export PS1='\w\[\033[01;34m\]\$(__git_ps1 \" (%s)\")\[\033[00m\] $ '"
+#### Copy-pasters: Here it is raw, unescaped for the echo command:
+# export PS1='\w\[\033[01;34m\]$(__git_ps1 " (%s)")\[\033[00m\] $ '
+echo "
+* To see results of terminal changes you may need to do
+  'source ~/.profile', or reopen Terminals.
+
+* Install finished. Do 'vagrant ssh' to get into this box, 'vagrant halt' to stop it.
+"

--- a/vm-setup/rottenpotatoes/Gemfile.lock
+++ b/vm-setup/rottenpotatoes/Gemfile.lock
@@ -37,13 +37,13 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.6.3)
-    columnize (0.3.6)
-    debugger (1.6.2)
+    columnize (0.8.9)
+    debugger (1.6.6)
       columnize (>= 0.3.1)
       debugger-linecache (~> 1.2.0)
-      debugger-ruby_core_source (~> 1.2.3)
+      debugger-ruby_core_source (~> 1.3.2)
     debugger-linecache (1.2.0)
-    debugger-ruby_core_source (1.2.3)
+    debugger-ruby_core_source (1.3.2)
     erubis (2.7.0)
     execjs (2.0.2)
     haml (4.0.4)
@@ -55,6 +55,7 @@ GEM
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
     json (1.8.1)
+    libv8 (3.16.14.3)
     mail (2.5.4)
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
@@ -92,6 +93,7 @@ GEM
     rake (10.1.0)
     rdoc (3.12.2)
       json (~> 1.4)
+    ref (1.0.5)
     sass (3.2.12)
     sass-rails (3.2.6)
       railties (~> 3.2.0)
@@ -103,6 +105,9 @@ GEM
       rack (~> 1.0)
       tilt (~> 1.1, != 1.3.0)
     sqlite3 (1.3.8)
+    therubyracer (0.12.1)
+      libv8 (~> 3.16.14.0)
+      ref
     thor (0.18.1)
     tilt (1.4.1)
     treetop (1.4.15)
@@ -126,4 +131,5 @@ DEPENDENCIES
   rails_12factor
   sass-rails (~> 3.2.3)
   sqlite3
+  therubyracer
   uglifier (>= 1.0.3)


### PR DESCRIPTION
See also https://github.com/saasbook/courseware/pull/7

Provisioning script heavily from the image provisioning script in same dir but left off the global gem install and vim emacs for initial add. Skipped a few things that we could add back in:
- skipped editor default configs - people will be able to use their host to access with any editor.
- skipped global gem installs: `gem install xyzgem`, just calling bundle install in rottenpotatoes so far.
- probably want to do that default setup to help all the people.
- do we want the jslint part? Left that in, may be in a video or the book?
- travis for this is missing, that would be some big downloads, travis cache is only supported on private repos