### PR TITLE
Get mpapis' gpg pubkey before RVM install

### DIFF
--- a/vm-setup/configure-image-0.10.3.sh
+++ b/vm-setup/configure-image-0.10.3.sh
@@ -42,6 +42,8 @@ echo "source ~/.profile" >> ~/.bash_profile
 
 # Install RVM and ruby 1.9.3 note: may take a while to compile ruby
 sudo-pw apt-get install -y curl
+# Get mpapis' pubkey per https://rvm.io/rvm/security
+gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
 set +v
 curl -L https://get.rvm.io | bash -s stable --ruby=1.9.3
 source ~/.rvm/scripts/rvm


### PR DESCRIPTION
RVM 1.26.0 was released on 2014-11-11.  Per the security release notes [1], the `rvm-installer` script is now signed by mpapis' gpg pubkey (key id `D39DC0E3`).  This signature is verified before RVM is installed; installation of RVM fails if a local copy of the pubkey is not available.  

Pull Request adds download of the requisite pubkey.  This was successfully tested on a clean install of 14.04 LTS.

[1] https://rvm.io/rvm/security