### PR TITLE
Use ruby 2.3.0 instead

### DIFF
--- a/vm-setup/configure-cloud9-1.1.2.sh
+++ b/vm-setup/configure-cloud9-1.1.2.sh
@@ -1,5 +1,5 @@
 # Please pipe this script to a "bash --login" shell
-RUBY=2.2.2
+RUBY=2.3.0
 set +v
 
 # to get /usr/share/dict/words


### PR DESCRIPTION
The CS169 homework's Gemfile requires using ruby 2.3.0.
