### PR TITLE
GitHub script2.0

### DIFF
--- a/scripts/github-repos/Gemfile
+++ b/scripts/github-repos/Gemfile
@@ -1,7 +1,6 @@
 source 'https://rubygems.org'
 
-ruby '3.2.2'
+ruby '< 3.0'
 
 gem 'octokit'
 gem 'csv'
-gem 'yaml'

--- a/scripts/github-repos/Gemfile.lock
+++ b/scripts/github-repos/Gemfile.lock
@@ -1,33 +1,33 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.8.4)
+    addressable (2.8.5)
       public_suffix (>= 2.0.2, < 6.0)
-    csv (3.2.6)
-    faraday (2.7.5)
+    base64 (0.1.1)
+    csv (3.2.7)
+    faraday (2.7.11)
+      base64
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (3.0.2)
-    octokit (6.1.1)
+    octokit (4.25.1)
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
-    public_suffix (5.0.1)
+    public_suffix (5.0.3)
     ruby2_keywords (0.0.5)
     sawyer (0.9.2)
       addressable (>= 2.3.5)
       faraday (>= 0.17.3, < 3)
-    yaml (0.2.1)
 
 PLATFORMS
-  x86_64-linux
+  arm64-darwin-22
 
 DEPENDENCIES
   csv
   octokit
-  yaml
 
 RUBY VERSION
-   ruby 3.2.2p53
+   ruby 2.6.10p210
 
 BUNDLED WITH
-   2.4.13
+   2.4.19

--- a/scripts/github-repos/README.md
+++ b/scripts/github-repos/README.md
@@ -15,18 +15,18 @@ If PREFIX is provided, it will assume the csv file contains "Team" column, and c
 the STUDENTTEAM, and invites them to child teams.
 
 Required options:
-    -c, --csv=CSVFILE                CSV file containing at leaset "Email/Username" named columns
+    -c, --csv=CSVFILE                CSV file containing at leaset "Email" named columns
     -s, --studentteam=STUDENTTEAM    The team name of all the students team
     -o, --orgname=ORGNAME            The name of the org
 
 Optional options:
     -p, --prefix=PREFIX              Semester prefix, eg fa23.
 
-'create_teams'
+'create_teams' (Not functioning)
 Assuming students are in STUDENTTEAM, create child teams for students for CHIP 10.5 and add them to the child team.
 
 Required options:
-    -c, --csv=CSVFILE                CSV file containing at least "Team" and "Email/Username" named columns
+    -c, --csv=CSVFILE                CSV file containing at least "Team" and "Email" named columns
     -s, --studentteam=STUDENTTEAM    The team name of all the students team
     -p, --prefix=PREFIX              Semester prefix, eg fa23.
     -o, --orgname=ORGNAME            The name of the org

--- a/scripts/github-repos/README.md
+++ b/scripts/github-repos/README.md
@@ -15,7 +15,7 @@ If PREFIX is provided, it will assume the csv file contains "Team" column, and c
 the STUDENTTEAM, and invites them to child teams.
 
 Required options:
-    -c, --csv=CSVFILE                CSV file containing at leaset "Email" named columns
+    -c, --csv=CSVFILE                CSV file containing at leaset "Username" named columns
     -s, --studentteam=STUDENTTEAM    The team name of all the students team
     -o, --orgname=ORGNAME            The name of the org
 
@@ -26,7 +26,7 @@ Optional options:
 Assuming students are in STUDENTTEAM, create child teams for students for CHIP 10.5 and add them to the child team.
 
 Required options:
-    -c, --csv=CSVFILE                CSV file containing at least "Team" and "Email" named columns
+    -c, --csv=CSVFILE                CSV file containing at least "Team" and "Username" named columns
     -s, --studentteam=STUDENTTEAM    The team name of all the students team
     -p, --prefix=PREFIX              Semester prefix, eg fa23.
     -o, --orgname=ORGNAME            The name of the org
@@ -90,7 +90,7 @@ Required options:
 
 This script creates a team that include all stundents in the same semester, eg fa23. 
 Then creates different child teams for them for the chip10.5. At a minimum, 
-you need a CSV file listing all enrolled students with columns 'Email' and 'Team'.  
+you need a CSV file listing all enrolled students with columns 'Username' and 'Team'.  
 The values in the Team columns should be nonnegative integers identifying teams.
 
 Org setting: Assume Base permissions is no permission, each students can only access their team repos.

--- a/scripts/github-repos/README.md
+++ b/scripts/github-repos/README.md
@@ -1,22 +1,76 @@
 # Bulk creation/deletion of many repos and cs169a-team
 
 ```
-Usage: ./github-repos.rb [required options] [invite|repos|remove|remove_access]
+Usage: ./github-repos.rb [required options] [invite|create_teams|indiv_repos|team_repos|remove_indivi_repos|remove_team_repos|remove_teams|remove_team_repo_access]
 
 GITHUB_ORG_API_KEY for the org must be set as an environment variable.
 
-'invite' invites students provided in .csv file and creates teams, 'repos' creates team repos, 'remove' remove students, repos, teams from the org
-
 It's safe to run multiple times.
 
+'invite':
+Create a team called STUDENTTEAM under the org that has all students in the same semester and send invitation
+
 Required arguments:
-    -c, --csv=CSVFILE                CSV file containing at least "Team" and "Email" named columns
-    -o, --orgname=ORGNAME            The name of the org eg org_name
-    -f, --filename=FILENAME          The base filename for repos, eg "fa23-actionmap-04", actionmap is the base file name of the repo
-    -p, --prefix=PREFIX              Semester prefix, eg "fa23" create a repos prefix, "fa23-actionmap-04", etc.
-    -t, --template=TEMPLATE          The repo name within the org to use as template eg repo_name (Assume the repo own by org)
+    -c, --csv=CSVFILE                CSV file containing at leaset "Email"/"Username" named columns
+    -s, --studentteam=STUDENTTEAM    The team name of all the students team
+
+'create_teams'
+Create child teams for students for CHIP 10.5
+
+Required arguments:
+    -c, --csv=CSVFILE                CSV file containing at least "Team" and "Email"/"Username" named columns
+    -s, --studentteam=STUDENTTEAM    The team name of all the students team
+    -p, --prefix=PREFIX              Semester prefix, eg fa23.
+
+'indiv_repos'
+Create CHIPS repo for each stedent in STUDENTTEAM. Repos' names are form like "PREFIX-[username]-FILENAME"
+
+Required arguments:
+    -s, --studentteam=STUDENTTEAM    The team name of all the students team
+    -p, --prefix=PREFIX              Semester prefix, eg fa23.
+    -t, --template=TEMPLATE          The repo name within the org to use as template
+    -g, --gsiteam=GSITEAM            The team name of all the staff team
+    -f, --filename=FILENAME          The base filename for repos
+
+'team_repos'
+Create 10.5 repos for each child team. Repos' names are form like "PREFIX-FILENAME-[Team number]"
+Make sure child teams are formed before running this method.
+
+Required arguments:
+    -p, --prefix=PREFIX              Semester prefix, eg fa23.
+    -t, --template=TEMPLATE          The repo name within the org to use as template
+    -f, --filename=FILENAME          The base filename for repos.
     -s, --studentteam=STUDENTTEAM    The team name of all the students team
     -g, --gsiteam=GSITEAM            The team name of all the staff team
+
+'remove_indiv_repos'
+Delete all repos whose names are formed like "PREFIX-[username]-FILENAME".
+
+Required arguments:
+    -p, --prefix=PREFIX              Semester prefix, eg fa23.
+    -f, --filename=FILENAME          The base filename for repos.
+
+'remove_team_repos'
+Delete all repos whose names are formed like "PREFIX-FILENAME-[Team number]".
+
+Required arguments:
+    -p, --prefix=PREFIX              Semester prefix, eg fa23.
+    -f, --filename=FILENAME          The base filename for repos.
+
+'remove_teams'
+Remove all students and child teams in STUDENTTEAM from the org.
+Remove STUDENTTEAM as well.
+
+Required arguments:
+    -p, --prefix=PREFIX              Semester prefix, eg fa23.
+    -s, --studentteam=STUDENTTEAM    The team name of all the students team
+
+'remove_team_repo_access'
+Remove students access to CHIP 10.5 repos that are formed like "PREFIX-FILENAME-[Team number]".
+
+Required arguments:
+    -p, --prefix=PREFIX              Semester prefix, eg fa23.
+    -f, --filename=FILENAME          The base filename for repos.
 ```
 
 This script creates a team that include all stundents in the same semester, eg fa23. 
@@ -28,26 +82,42 @@ Org setting: Assume Base permissions is no permission, each students can only ac
 
 **Assumption:** You have a GITHUB ORG API key.
 
-### Create a team under the org that includes all students in the same semester
+### Create a team under the org that has all students in the same semester and send invitation
 
 **Use case:** Create a team called STUDENTTEAM, and send invitations 
-to the students in csv file. If STUDENTTEAM exists, delete the team and 
-create a new one. (Team repos still exist) 
-For all students NOT in that team, add/invite into that team.
+to the students in csv file. If STUDENTTEAM exists, delete STUDENTTEAM and 
+create a new one. (Team repos still exist)
+For all students NOT in STUDENTTEAM, add/invite into STUDENTTEAM.
+Team column is not needed for this.
+
+### Create child teams for students for CHIP 10.5
+
+**Use case:** Create child teams for students for CHIP 10.5. 
+
+### Create CHIPS repo for each stedent
+
+**Use case:** Create CHIP repos for each student in STUDENTTEAM.
+The repos' names are formed like  "fa23-[username]-FILENAME". There will 
+be only one collabrator. Add all repos to the gsiteam with admin permission.
 
 ### Create 10.5 repos for each child team 
 
 **Use case:** Each team (as identified by Team column in CSV file)
-gets a repo for chip 10.5.  Repos' names are formed
-by concatenating the prefix, base file name, and the team ID. 
-(eg "fa23-actionmap-04" for team #4) For all students on that team who do 
-NOT already have access to the repo, give them write access on the repo.
+gets a repo for chip 10.5.  Repos' names are formed like "PREFIX-FILENAME-TEAMNUM"
+Every one in the child team has write access to the repo.
 Add all repos to the gsiteam with admin permission.
 
-### Remove all team members from students team, and delete all the repos
+### Remove the CHIPS repos
 
-**Use case:** Delete all repos whose name matches the "PREFIX-FILENAME-team number".
-Remove all students and subteams in STUDENTTEAM from the org.
+**Use case:** Delete all repos whose names are formed like "PREFIX-[username]-FILENAME".
+
+### Remove CHIP 10.5 repos
+
+**Use case:** Delete all repos whose names are formed like "PREFIX-FILENAME-[Team number]".
+
+### Remove all team members from students teams, then delete all teams
+
+**Use case:** Remove all students and subteams in STUDENTTEAM from the org.
 
 ### Remove student access to all the chip 10.5 repos 
 

--- a/scripts/github-repos/README.md
+++ b/scripts/github-repos/README.md
@@ -23,17 +23,19 @@ Optional options:
     -p, --prefix=PREFIX              Semester prefix, eg fa23.
 
 'create_teams'
-Create child teams for students for CHIP 10.5
+Assuming students are in STUDENTTEAM, create child teams for students for CHIP 10.5 and add them to the child team.
 
 Required options:
     -c, --csv=CSVFILE                CSV file containing at least "Team" and "Email/Username" named columns
     -s, --studentteam=STUDENTTEAM    The team name of all the students team
     -p, --prefix=PREFIX              Semester prefix, eg fa23.
+    -o, --orgname=ORGNAME            The name of the org
 
 'indiv_repos'
 Create CHIPS repo for each stedent in STUDENTTEAM. Repos' names are form like "PREFIX-[username]-FILENAME"
 
 Required options:
+    -o, --orgname=ORGNAME            The name of the org
     -s, --studentteam=STUDENTTEAM    The team name of all the students team
     -p, --prefix=PREFIX              Semester prefix, eg fa23.
     -t, --template=TEMPLATE          The repo name within the org to use as template
@@ -42,9 +44,10 @@ Required options:
 
 'team_repos'
 Create 10.5 repos for each child team. Repos' names are form like "PREFIX-FILENAME-[Team number]"
-Make sure child teams are formed before running this method.
+Make sure child teams are formed before running this command.
 
 Required options:
+    -o, --orgname=ORGNAME            The name of the org
     -p, --prefix=PREFIX              Semester prefix, eg fa23.
     -t, --template=TEMPLATE          The repo name within the org to use as template
     -f, --filename=FILENAME          The base filename for repos.
@@ -55,6 +58,7 @@ Required options:
 Delete all repos whose names are formed like "PREFIX-[username]-FILENAME".
 
 Required options:
+    -o, --orgname=ORGNAME            The name of the org
     -p, --prefix=PREFIX              Semester prefix, eg fa23.
     -f, --filename=FILENAME          The base filename for repos.
 
@@ -62,6 +66,7 @@ Required options:
 Delete all repos whose names are formed like "PREFIX-FILENAME-[Team number]".
 
 Required options:
+    -o, --orgname=ORGNAME            The name of the org
     -p, --prefix=PREFIX              Semester prefix, eg fa23.
     -f, --filename=FILENAME          The base filename for repos.
 
@@ -70,6 +75,7 @@ Remove all students and child teams in STUDENTTEAM from the org.
 Remove STUDENTTEAM as well.
 
 Required options:
+    -o, --orgname=ORGNAME            The name of the org
     -p, --prefix=PREFIX              Semester prefix, eg fa23.
     -s, --studentteam=STUDENTTEAM    The team name of all the students team
 
@@ -77,6 +83,7 @@ Required options:
 Remove students access to CHIP 10.5 repos that are formed like "PREFIX-FILENAME-[Team number]".
 
 Required options:
+    -o, --orgname=ORGNAME            The name of the org
     -p, --prefix=PREFIX              Semester prefix, eg fa23.
     -f, --filename=FILENAME          The base filename for repos.
 ```

--- a/scripts/github-repos/README.md
+++ b/scripts/github-repos/README.md
@@ -1,7 +1,7 @@
-# Bulk creation/deletion of many repos and cs169a-team
+# Bulk creation/deletion of many repos and student teams
 
 ```
-Usage: ./github-repos.rb [required options] [invite|create_teams|indiv_repos|team_repos|remove_indivi_repos|remove_team_repos|remove_teams|remove_team_repo_access]
+Usage: ./github-repos.rb [required options] [invite|create_teams|indiv_repos|team_repos|remove_indivi_repos|remove_team_repos|remove_teams|remove_team_repo_access] [optional options]
 
 GITHUB_ORG_API_KEY for the org must be set as an environment variable.
 
@@ -9,23 +9,31 @@ It's safe to run multiple times.
 
 'invite':
 Create a team called STUDENTTEAM under the org that has all students in the same semester and send invitation
+If STUDENTTEAM is already exist, the script will resent invitation to students. 
+(Temporary for special situations in Fa23)
+If PREFIX is provided, it will assume the csv file contains "Team" column, and create child teams under 
+the STUDENTTEAM, and invites them to child teams.
 
-Required arguments:
-    -c, --csv=CSVFILE                CSV file containing at leaset "Email"/"Username" named columns
+Required options:
+    -c, --csv=CSVFILE                CSV file containing at leaset "Email/Username" named columns
     -s, --studentteam=STUDENTTEAM    The team name of all the students team
+    -o, --orgname=ORGNAME            The name of the org
+
+Optional options:
+    -p, --prefix=PREFIX              Semester prefix, eg fa23.
 
 'create_teams'
 Create child teams for students for CHIP 10.5
 
-Required arguments:
-    -c, --csv=CSVFILE                CSV file containing at least "Team" and "Email"/"Username" named columns
+Required options:
+    -c, --csv=CSVFILE                CSV file containing at least "Team" and "Email/Username" named columns
     -s, --studentteam=STUDENTTEAM    The team name of all the students team
     -p, --prefix=PREFIX              Semester prefix, eg fa23.
 
 'indiv_repos'
 Create CHIPS repo for each stedent in STUDENTTEAM. Repos' names are form like "PREFIX-[username]-FILENAME"
 
-Required arguments:
+Required options:
     -s, --studentteam=STUDENTTEAM    The team name of all the students team
     -p, --prefix=PREFIX              Semester prefix, eg fa23.
     -t, --template=TEMPLATE          The repo name within the org to use as template
@@ -36,7 +44,7 @@ Required arguments:
 Create 10.5 repos for each child team. Repos' names are form like "PREFIX-FILENAME-[Team number]"
 Make sure child teams are formed before running this method.
 
-Required arguments:
+Required options:
     -p, --prefix=PREFIX              Semester prefix, eg fa23.
     -t, --template=TEMPLATE          The repo name within the org to use as template
     -f, --filename=FILENAME          The base filename for repos.
@@ -46,14 +54,14 @@ Required arguments:
 'remove_indiv_repos'
 Delete all repos whose names are formed like "PREFIX-[username]-FILENAME".
 
-Required arguments:
+Required options:
     -p, --prefix=PREFIX              Semester prefix, eg fa23.
     -f, --filename=FILENAME          The base filename for repos.
 
 'remove_team_repos'
 Delete all repos whose names are formed like "PREFIX-FILENAME-[Team number]".
 
-Required arguments:
+Required options:
     -p, --prefix=PREFIX              Semester prefix, eg fa23.
     -f, --filename=FILENAME          The base filename for repos.
 
@@ -61,14 +69,14 @@ Required arguments:
 Remove all students and child teams in STUDENTTEAM from the org.
 Remove STUDENTTEAM as well.
 
-Required arguments:
+Required options:
     -p, --prefix=PREFIX              Semester prefix, eg fa23.
     -s, --studentteam=STUDENTTEAM    The team name of all the students team
 
 'remove_team_repo_access'
 Remove students access to CHIP 10.5 repos that are formed like "PREFIX-FILENAME-[Team number]".
 
-Required arguments:
+Required options:
     -p, --prefix=PREFIX              Semester prefix, eg fa23.
     -f, --filename=FILENAME          The base filename for repos.
 ```

--- a/scripts/github-repos/github-repos.rb
+++ b/scripts/github-repos/github-repos.rb
@@ -77,6 +77,8 @@ class OrgManager
 
     public
 
+
+    
     def valid?
         @orgname && @base_filename && @semester && @childteams.length > 0 && @template && @parentteam && gsiteam_valid?
     end

--- a/scripts/github-repos/github-repos.rb
+++ b/scripts/github-repos/github-repos.rb
@@ -7,222 +7,344 @@ require 'csv'
 ENV['GITHUB_ORG_API_KEY'] = ""
 
 def main()
-    puts "Script start."
-    org = OrgManager.new
-    $opts = OptionParser.new do |opt|
-        opt.banner = "Usage: #{__FILE__} [required options] [invite|repos|remove]
-    GITHUB_ORG_API_KEY for the org must be set as an environment variable.
-    'invite' invites students provided in .csv file and creates teams, 
-    'repos' creates team repos, 'remove' remove students, repos, teams from the org."
-        opt.on('-cCSVFILE', '--csv=CSVFILE', 'CSV file containing at least "Team" and "Email" named columns') do |csv|
-        org.read_teams_and_emails_from csv
-        end
-        opt.on('-oORGNAME', '--orgname=ORGNAME', 'The name of the org') do |orgname|
+  puts "Script start."
+  org = OrgManager.new
+  $opts = OptionParser.new do |opt|
+    opt.banner = "Usage: #{__FILE__} [required options] [invite|create_teams|indiv_repos|team_repos|
+    remove_indivi_repos|remove_team_repos|remove_teams|remove_team_repo_access] [optional options]
+    GITHUB_ORG_API_KEY for the org must be set as an environment variable."
+
+    opt.separator ""
+    opt.separator "Commands:"
+    opt.separator "    invite: Create a team called STUDENTTEAM under the org..."
+    opt.separator "            If STUDENTTEAM is already exist, the script will resent invitation to students."
+    opt.separator "            (Temporary for special situations in Fa23)"
+    opt.separator "            If PREFIX is provided, it will assume the csv file contains \"Team\" column, and create child teams under the STUDENTTEAM, and invites them to child teams.\n"
+    opt.separator "    create_teams: Create child teams for students for CHIP 10.5 \n"
+    opt.separator "    indiv_repos: Create CHIPS repo for each stedent in STUDENTTEAM. Repos' names are form like \"PREFIX-[username]-FILENAME\"\n"
+    opt.separator "    team_repos: Create 10.5 repos for each child team. Repos' names are form like \"PREFIX-FILENAME-[Team number]\""
+    opt.separator "                Make sure child teams are formed before running this method.\n"
+    opt.separator "    remove_indiv_repos: Delete all repos whose names are formed like \"PREFIX-[username]-FILENAME\".\n"
+    opt.separator "    remove_team_repos: Delete all repos whose names are formed like \"PREFIX-FILENAME-[Team number]\".\n"
+    opt.separator "    remove_teams: Remove all students and child teams in STUDENTTEAM from the org. Remove STUDENTTEAM as well.\n"
+    opt.separator "    remove_team_repo_access: Remove students access to CHIP 10.5 repos that are formed like \"PREFIX-FILENAME-[Team number]\".\n"
+    opt.separator "Required options:"
+
+    case ARGV[0]
+    when 'invite'
+      opt.on('-cCSVFILE', '--csv=CSVFILE', 'CSV file containing at leaset "Email" named columns') do |csv|
+        org.csv = csv
+      end
+      opt.on('-oORGNAME', '--orgname=ORGNAME', 'The name of the org') do |orgname|
         org.orgname = orgname
-        end
-        opt.on('-fFILENAME', '--filename=FILENAME', 'The base filename for repos') do |filename|
-        org.base_filename = filename
-        end
-        opt.on('-pPREFIX', '--prefix=PREFIX', 'Semester prefix, eg "fa23" create a repos prefix, "fa23-actionmap-04", etc') do |pfx|
-        org.semester = pfx
-        end
-        opt.on('-tTEMPLATE', '--template=TEMPLATE', 'The repo name within the org to use as template eg repo_name') do |template|
-        org.template = template
-        end
-        opt.on('-sSTUDENTTEAM', '--studentteam=STUDENTTEAM', 'The team name of all the students team') do |studentteam|
+      end
+      opt.on('-sSTUDENTTEAM', '--studentteam=STUDENTTEAM', 'The team name of all the students team') do |studentteam|
         org.parentteam = studentteam
-        end
-        opt.on('-gGSITEAM', '--gsiteam=GSITEAM', 'The team name of all the staff team') do |gsiteam|
+      end
+      opt.separator "Optional options:"
+      opt.on('-pPREFIX', '--prefix=PREFIX', 'Semester prefix, eg fa23.') do |pfx|
+        org.semester = pfx
+      end
+    when 'create_teams'
+      opt.on('-cCSVFILE', '--csv=CSVFILE', 'CSV file containing at least "Team" and "Email" named columns') do |csv|
+        org.read_teams_and_users_from csv
+      end
+      opt.on('-sSTUDENTTEAM', '--studentteam=STUDENTTEAM', 'The team name of all the students team') do |studentteam|
+        org.parentteam = studentteam
+      end
+      opt.on('-pPREFIX', '--prefix=PREFIX', 'Semester prefix, eg fa23.') do |pfx|
+        org.semester = pfx
+      end
+    when 'indiv_repos'
+      opt.on('-fFILENAME', '--filename=FILENAME', 'The base filename for repos') do |filename|
+        org.base_filename = filename
+      end
+      opt.on('-pPREFIX', '--prefix=PREFIX', 'Semester prefix, eg fa23.') do |pfx|
+        org.semester = pfx
+      end
+      opt.on('-tTEMPLATE', '--template=TEMPLATE', 'The repo name within the org to use as template') do |template|
+        org.template = template
+      end
+      opt.on('-sSTUDENTTEAM', '--studentteam=STUDENTTEAM', 'The team name of all the students team') do |studentteam|
+        org.parentteam = studentteam
+      end
+      opt.on('-gGSITEAM', '--gsiteam=GSITEAM', 'The team name of all the staff team') do |gsiteam|
         org.gsiteam = gsiteam
-        end
+      end
+    when 'team_repos'      
+      opt.on('-fFILENAME', '--filename=FILENAME', 'The base filename for repos') do |filename|
+        org.base_filename = filename
+      end
+      opt.on('-pPREFIX', '--prefix=PREFIX', 'Semester prefix, eg fa23.') do |pfx|
+        org.semester = pfx
+      end
+      opt.on('-tTEMPLATE', '--template=TEMPLATE', 'The repo name within the org to use as template') do |template|
+        org.template = template
+      end
+      opt.on('-sSTUDENTTEAM', '--studentteam=STUDENTTEAM', 'The team name of all the students team') do |studentteam|
+        org.parentteam = studentteam
+      end
+      opt.on('-gGSITEAM', '--gsiteam=GSITEAM', 'The team name of all the staff team') do |gsiteam|
+        org.gsiteam = gsiteam
+      end
+    when 'remove_idiv_repos'
+      opt.on('-pPREFIX', '--prefix=PREFIX', 'Semester prefix, eg fa23.') do |pfx|
+        org.semester = pfx
+      end
+      opt.on('-fFILENAME', '--filename=FILENAME', 'The base filename for repos') do |filename|
+        org.base_filename = filename
+      end
+    when 'remove_team_repos'
+      opt.on('-pPREFIX', '--prefix=PREFIX', 'Semester prefix, eg fa23.') do |pfx|
+        org.semester = pfx
+      end
+      opt.on('-fFILENAME', '--filename=FILENAME', 'The base filename for repos') do |filename|
+        org.base_filename = filename
+      end
+    when 'remove_teams'
+      opt.on('-pPREFIX', '--prefix=PREFIX', 'Semester prefix, eg fa23.') do |pfx|
+        org.semester = pfx
+      end
+      opt.on('-sSTUDENTTEAM', '--studentteam=STUDENTTEAM', 'The team name of all the students team') do |studentteam|
+        org.parentteam = studentteam
+      end
+    when 'remove_team_repo_access'
+      opt.on('-fFILENAME', '--filename=FILENAME', 'The base filename for repos') do |filename|
+        org.base_filename = filename
+      end
+      opt.on('-pPREFIX', '--prefix=PREFIX', 'Semester prefix, eg fa23.') do |pfx|
+        org.semester = pfx
+      end
     end
-    $opts.parse!
-    command = ARGV.pop
-    case command
-    when 'invite' then org.invite
-    when 'repos' then org.create_repos 
-    when 'remove' then org.remove
-    when 'remove_access' then org.remove_access
-    else org.print_error
-    end
-    puts "Run successfully."
-    puts "Script ends."
+  end
+  $opts.parse!
+  command = ARGV.pop
+  # case command
+  # when 'invite' then org.invite
+  # when 'repos' then org.create_repos 
+  # when 'remove' then org.remove
+  # when 'remove_access' then org.remove_access
+  # else org.print_error
+  # end
+  case command
+  when 'invite' then org.invite
+  when 'create_teams'
+  when 'indiv_repos'
+  when 'team_repos'  
+  when 'remove_idiv_repos'
+  when 'remove_team_repos'
+  when 'remove_teams'
+  when 'remove_team_repo_access'
+  else org.print_error
+  end
+  puts "Run successfully."
+  puts "Script ends."
 end
 
 class OrgManager
-    attr_accessor :orgname, :base_filename, :semester, :template, :parentteam, :gsiteam
+  attr_accessor :orgname, :base_filename, :semester, :template, :parentteam, :gsiteam, :csv, :users
 
-    def initialize
-        @orgname = nil
-        @base_filename = nil
-        @semester = nil
-        @template = nil
-        @childteams = Hash.new { |hash, key| hash[key] = [] } # teamID => [email1, email2, ...]
-        print_error("GITHUB_ORG_API_KEY not defined in environment") unless (@key = ENV['GITHUB_ORG_API_KEY'])
-        @client = Octokit::Client.new(access_token: @key)
+  def initialize
+    @orgname = nil
+    @base_filename = nil
+    @semester = nil
+    @template = nil
+    @has_childteams = false
+    @users = []
+    @childteams = Hash.new { |hash, key| hash[key] = [] } # teamID => [email1, email2, ...]
+    print_error("GITHUB_ORG_API_KEY not defined in environment") unless (@key = ENV['GITHUB_ORG_API_KEY'])
+    @client = Octokit::Client.new(access_token: @key)
+  end
+
+  private
+
+  def read_users_from csv
+    data = CSV.parse(IO.read(csv), headers: true)
+    hash = data.first.to_h
+    print_error "Need at least 'Email' (str) columns in #{csv}" unless
+      hash.has_key?('Email')
+    data.each do |row|
+      @users << username
     end
+  end
 
-    private
+  def read_teams_and_users_from csv
+    data = CSV.parse(IO.read(csv), headers: true)
+    hash = data.first.to_h
+    print_error "Need at least 'Team' (int) and 'Email' (str) columns in #{csv}" unless
+      hash.has_key?('Team') && hash.has_key?('Email')
+    data.each do |row|
+      username = row['Email']
+      @childteams[row['Team']] << username
+    end
+  end
 
-    def gsiteam_valid?
-        gsiteam_obj = nil
-        if !@gsiteam.nil? && @gsiteam.length > 0 
-            begin
-                gsiteam_obj = @client.team_by_name(@orgname, @gsiteam)
-            rescue Octokit::NotFound
-            end
+  def invite_valid?
+    # process the csv file
+    if @orgname.nil? || @orgname.empty? || @csv.nil? || @parentteam.nil? || @parentteam.empty?
+      return false
+    end
+    if @semester.nil?
+      read_users_from @csv
+    else
+      read_teams_and_users_from @csv
+    end
+    true
+  end
+
+  def gsiteam_valid?
+    gsiteam_obj = nil
+    if !@gsiteam.nil? && @gsiteam.length > 0 
+      begin
+        gsiteam_obj = @client.team_by_name(@orgname, @gsiteam)
+      rescue Octokit::NotFound
+      end
+    end
+    !gsiteam_obj.nil?
+  end
+
+  public
+
+  def valid?
+    @orgname && @base_filename && @semester && @childteams.length > 0 && @template && @parentteam && gsiteam_valid?
+  end
+
+  def print_error(msg=nil)
+    STDERR.puts "Error: #{msg}" if msg
+    STDERR.puts $opts
+    exit 1
+  end
+
+  def invite
+    print_error "csv file, organization name, student team name are needed." unless valid?
+    if @semester.nil? 
+      # Semester prefix is not provided
+
+      # Looking for the STUDENTTEAM in the org, see if it is exist.
+      begin
+        parentteam_id = @client.team_by_name(@orgname, @parentteam)['id']
+      rescue Octokit::NotFound
+        parentteam_id = @client.create_team(@orgname, {name: @parentteam, privacy: 'closed'})['id']
+      end
+
+      @users.each do |student_email|
+        if !@client.team_invitations(parentteam_id).any? {|invitations| invitations.email == member}
+          # invitation is not pending, send invitation
+          begin
+            @client.post(%Q{/orgs/#{@orgname}/invitations}, {org: @orgname, email: student_email , role: 'direct_member', team_ids: [parentteam_id]})
+          rescue Octokit::UnprocessableEntity
+            # send fail, member is already a part of org
+            next
+          end
         end
-        !gsiteam_obj.nil?
-    end
+      end
+    else
+      # Semester prefix is provied
+      
+      # Looking for the STUDENTTEAM in the org, see if it is exist.
+      begin
+        parentteam_id = @client.team_by_name(@orgname, @parentteam)['id']
+      rescue Octokit::NotFound
+        parentteam_id = @client.create_team(@orgname, {name: @parentteam, privacy: 'closed'})['id']
+      end
 
-    public
-
-
-    
-    def valid?
-        @orgname && @base_filename && @semester && @childteams.length > 0 && @template && @parentteam && gsiteam_valid?
-    end
-
-    def print_error(msg=nil)
-        STDERR.puts "Error: #{msg}" if msg
-        STDERR.puts $opts
-        exit 1
-    end
-
-    def read_teams_and_emails_from csv
-        data = CSV.parse(IO.read(csv), headers: true)
-        hash = data.first.to_h
-        print_error "Need at least 'Team' (int) and 'Email' (str) columns in #{csv}" unless
-          hash.has_key?('Team') && hash.has_key?('Email')
-        data.each do |row|
-          username = row['Email']
-          @childteams[row['Team']] << username
-        end
-    end
-
-    def invite
-        print_error "csv file, base filename, template repo name, semester prefix, students team name, and gsi team name needed." unless valid?
-        first_child_team_name = %Q{#{@semester}-#{@childteams.keys[0]}}
-
+      # create child teams and invite students to the child teams
+      # this is for Fa23, will delete in the future. 
+      @childteams.each_key do |team|
+        childteam_name = %Q{#{@semester}-#{team}}
         begin
-            parentteam_obj = @client.team_by_name(@orgname, @parentteam)
+          childteam = @client.team_by_name(@orgname, childteam_name)
         rescue Octokit::NotFound
-            parentteam_obj = nil
+          childteam = @client.create_team(@orgname, {name: %Q{#{@semester}-#{team}}, parent_team_id: parentteam_id})
         end
+        childteam_id = childteam['id']
+        @childteams[team].each do |member|
+          # Try no check invitations before create one.
+          if !@client.team_invitations(childteam_id).any? {|invitations| invitations.email == member}
+            # send invitation
+            begin
+              @client.post(%Q{/orgs/#{@orgname}/invitations}, {org: @orgname, email: member, role: 'direct_member', team_ids: [childteam_id]})
+            rescue Octokit::UnprocessableEntity
+              # member is already a part of org
+              next
+            end
+          end
+        end
+      end
 
+    end
+  end
+
+  def create_repos
+    print_error "csv file, base filename, template repo name, semester prefix, students team name, and gsi team name needed." unless valid?
+    @childteams.each_key do |team|
+      begin
+        team_id = @client.team_by_name(@orgname, %Q{#{@semester}-#{team}})['id']
+      rescue Octokit::NotFound
+        print_error "Students teams information mismatched."
+      end
+      gsiteam_id = @client.team_by_name(@orgname, @gsiteam)['id']
+      new_repo_name = %Q{#{@semester}-#{@base_filename}-#{team}}
+      if !@client.repository? %Q{#{@orgname}/#{new_repo_name}}
         begin
-            if parentteam_obj
-                @client.team_by_name(@orgname, first_child_team_name)
-                parentteam_id = parentteam_obj['id']
-            else
-                parentteam_id = @client.create_team(@orgname, {name: @parentteam, privacy: 'closed'})['id']
-            end
+          new_repo = @client.create_repository_from_template(%Q{#{@orgname}/#{@template}}, new_repo_name, 
+            {owner: @orgname, private: true})
         rescue Octokit::NotFound
-            # students team exists before invite
-            # remove all members in this team, and delete the team.
-            parentteam_id = parentteam_obj['id']
-            old_team_members = @client.team_members(parentteam_id)
-            old_team_members.each do |member|
-                if @client.organization_membership(@orgname, :user => member['login'])['role'] == 'member'
-                    @client.remove_organization_member(@orgname, member['login'])
-                end
-            end
-            @client.delete_team parentteam_id
-            parentteam_id = @client.create_team(@orgname, {name: @parentteam, privacy: 'closed'})['id']
+          print_error "Template not found."
         end
-
-        @childteams.each_key do |team|
-            childteam_name = %Q{#{@semester}-#{team}}
-            begin
-                childteam = @client.team_by_name(@orgname, childteam_name)
-            rescue Octokit::NotFound
-                childteam = @client.create_team(@orgname, {name: %Q{#{@semester}-#{team}}, parent_team_id: parentteam_id})
-            end
-            childteam_id = childteam['id']
-            @childteams[team].each do |member|
-                if !@client.team_invitations(childteam_id).any? {|invitations| invitations.email == member}
-                    # send invitation
-                    begin
-                        @client.post(%Q{/orgs/#{@orgname}/invitations}, {org: @orgname, email: member, role: 'direct_member', team_ids: [childteam_id]})
-                    rescue Octokit::UnprocessableEntity
-                        # member is already a part of org
-                        next
-                    end
-                end
-            end
-        end
+        @client.add_team_repository(team_id, new_repo['full_name'], {permission: 'push'})
+        @client.add_team_repository(gsiteam_id, new_repo['full_name'], {permission: 'admin'})
+      end
     end
+  end
 
-    def create_repos
-        print_error "csv file, base filename, template repo name, semester prefix, students team name, and gsi team name needed." unless valid?
-        @childteams.each_key do |team|
-            begin
-                team_id = @client.team_by_name(@orgname, %Q{#{@semester}-#{team}})['id']
-            rescue Octokit::NotFound
-                print_error "Students teams information mismatched."
-            end
-            gsiteam_id = @client.team_by_name(@orgname, @gsiteam)['id']
-            new_repo_name = %Q{#{@semester}-#{@base_filename}-#{team}}
-            if !@client.repository? %Q{#{@orgname}/#{new_repo_name}}
-                begin
-                    new_repo = @client.create_repository_from_template(%Q{#{@orgname}/#{@template}}, new_repo_name, 
-                        {owner: @orgname, private: true})
-                rescue Octokit::NotFound
-                    print_error "Template not found."
-                end
-                @client.add_team_repository(team_id, new_repo['full_name'], {permission: 'push'})
-                @client.add_team_repository(gsiteam_id, new_repo['full_name'], {permission: 'admin'})
-            end
+  def remove
+    print_error "csv file, base filename, template repo name, semester prefix, students team name, and gsi team name needed." unless valid?
+    # remove and delete all repos from the students team, delete all child teams
+    # also cancel all pending invitaions
+    @childteams.each_key do |team|
+      repo_name = %Q{#{@orgname}/#{@semester}-#{@base_filename}-#{team}}
+      @client.delete_repository(repo_name)
+      begin
+        childteam_id = @client.team_by_name(@orgname, %Q{#{@semester}-#{team}})['id'] # eg slug fa23-01
+      rescue Octokit::NotFound
+        next
+      end
+
+      # remove students from the student teams
+      team_members = @client.team_members(childteam_id)
+      team_members.each do |member|
+        if @client.organization_membership(@orgname, :user => member['login'])['role'] == 'member'
+          @client.remove_organization_member(@orgname, member['login'])
         end
+      end
+
+      @client.team_invitations(childteam_id).each do |invitation|
+        # cancel all pending invitations
+        @client.delete(%Q{/orgs/#{@orgname}/invitations/#{invitation[:id]}})
+      end
+      @client.delete_team childteam_id
     end
-
-    def remove
-        print_error "csv file, base filename, template repo name, semester prefix, students team name, and gsi team name needed." unless valid?
-        # remove and delete all repos from the students team, delete all child teams
-        # also cancel all pending invitaions
-        @childteams.each_key do |team|
-            repo_name = %Q{#{@orgname}/#{@semester}-#{@base_filename}-#{team}}
-            @client.delete_repository(repo_name)
-            begin
-                childteam_id = @client.team_by_name(@orgname, %Q{#{@semester}-#{team}})['id'] # eg slug fa23-01
-            rescue Octokit::NotFound
-                next
-            end
-
-            # remove students from the student teams
-            team_members = @client.team_members(childteam_id)
-            team_members.each do |member|
-                if @client.organization_membership(@orgname, :user => member['login'])['role'] == 'member'
-                    @client.remove_organization_member(@orgname, member['login'])
-                end
-            end
-
-            @client.team_invitations(childteam_id).each do |invitation|
-                # cancel all pending invitations
-                @client.delete(%Q{/orgs/#{@orgname}/invitations/#{invitation[:id]}})
-            end
-            @client.delete_team childteam_id
-        end
-        # delete students team
-        begin
-            team_id = @client.team_by_name(@orgname, @parentteam)['id']
-            @client.delete_team team_id
-        rescue Octokit::NotFound
-            # do nothing if no such team
-        end
+    # delete students team
+    begin
+      team_id = @client.team_by_name(@orgname, @parentteam)['id']
+      @client.delete_team team_id
+    rescue Octokit::NotFound
+      # do nothing if no such team
     end
-    
-    def remove_access
-        @childteams.each_key do |team|
-            repo_name = %Q{#{@orgname}/#{@semester}-#{@base_filename}-#{team}}
-            begin
-                childteam_id = @client.team_by_name(@orgname, %Q{#{@semester}-#{team}})['id'] # eg slug fa23-1
-            rescue Octokit::NotFound
-                next
-            end
-            @client.remove_team_repository(childteam_id, repo_name)
-        end
+  end
+  
+  def remove_access
+    @childteams.each_key do |team|
+      repo_name = %Q{#{@orgname}/#{@semester}-#{@base_filename}-#{team}}
+      begin
+        childteam_id = @client.team_by_name(@orgname, %Q{#{@semester}-#{team}})['id'] # eg slug fa23-1
+      rescue Octokit::NotFound
+        next
+      end
+      @client.remove_team_repository(childteam_id, repo_name)
     end
+  end
 end
 
 main

--- a/scripts/github-repos/github-repos.rb
+++ b/scripts/github-repos/github-repos.rb
@@ -62,7 +62,7 @@ def main()
   when 'remove_indiv_repos' then org.remove_indiv_repos
   when 'remove_team_repos' then org.remove_team_repos
   when 'remove_teams' then org.remove_teams
-  when 'remove_team_repo_access'
+  when 'remove_team_repo_access' then org.remove_team_repo_access
   else org.print_error
   end
   puts "Run successfully."
@@ -392,7 +392,7 @@ end
     @client.delete_team parentteam_id
   end
 
-  def remove_access
+  def remove_team_repo_access
     print_error "org name, base filename, semester prefix are needed." unless remove_valid?
 
     repos = @client.org_repos(@orgname, {:type => 'private'})

--- a/scripts/github-repos/github-repos.rb
+++ b/scripts/github-repos/github-repos.rb
@@ -4,7 +4,7 @@ require 'optparse'
 require 'octokit'
 require 'csv'
 
-ENV['GITHUB_ORG_API_KEY'] = ""
+ENV['GITHUB_ORG_API_KEY'] = "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"
 
 def main()
   puts "Script start."
@@ -28,114 +28,28 @@ def main()
     opt.separator "    remove_team_repos: Delete all repos whose names are formed like \"PREFIX-FILENAME-[Team number]\".\n"
     opt.separator "    remove_teams: Remove all students and child teams in STUDENTTEAM from the org. Remove STUDENTTEAM as well.\n"
     opt.separator "    remove_team_repo_access: Remove students access to CHIP 10.5 repos that are formed like \"PREFIX-FILENAME-[Team number]\".\n"
-    opt.separator "Required options:"
+    opt.separator "Options:"
 
-    case ARGV[0]
-    when 'invite'
-      opt.on('-cCSVFILE', '--csv=CSVFILE', 'CSV file containing at leaset "Email" named columns') do |csv|
-        org.csv = csv
-      end
-      opt.on('-oORGNAME', '--orgname=ORGNAME', 'The name of the org') do |orgname|
-        org.orgname = orgname
-      end
-      opt.on('-sSTUDENTTEAM', '--studentteam=STUDENTTEAM', 'The team name of all the students team') do |studentteam|
-        org.parentteam = studentteam
-      end
-      opt.separator "Optional options:"
-      opt.on('-pPREFIX', '--prefix=PREFIX', 'Semester prefix, eg fa23.') do |pfx|
-        org.semester = pfx
-      end
-    when 'create_teams'
-      opt.on('-cCSVFILE', '--csv=CSVFILE', 'CSV file containing at least "Team" and "Email" named columns') do |csv|
-        org.csv = csv
-      end
-      opt.on('-sSTUDENTTEAM', '--studentteam=STUDENTTEAM', 'The team name of all the students team') do |studentteam|
-        org.parentteam = studentteam
-      end
-      opt.on('-pPREFIX', '--prefix=PREFIX', 'Semester prefix, eg fa23.') do |pfx|
-        org.semester = pfx
-      end
-      opt.on('-oORGNAME', '--orgname=ORGNAME', 'The name of the org') do |orgname|
-        org.orgname = orgname
-      end
-    when 'indiv_repos'
-      opt.on('-fFILENAME', '--filename=FILENAME', 'The base filename for repos') do |filename|
-        org.base_filename = filename
-      end
-      opt.on('-pPREFIX', '--prefix=PREFIX', 'Semester prefix, eg fa23.') do |pfx|
-        org.semester = pfx
-      end
-      opt.on('-tTEMPLATE', '--template=TEMPLATE', 'The repo name within the org to use as template') do |template|
-        org.template = template
-      end
-      opt.on('-sSTUDENTTEAM', '--studentteam=STUDENTTEAM', 'The team name of all the students team') do |studentteam|
-        org.parentteam = studentteam
-      end
-      opt.on('-gGSITEAM', '--gsiteam=GSITEAM', 'The team name of all the staff team') do |gsiteam|
-        org.gsiteam = gsiteam
-      end
-      opt.on('-oORGNAME', '--orgname=ORGNAME', 'The name of the org') do |orgname|
-        org.orgname = orgname
-      end
-    when 'team_repos'      
-      opt.on('-fFILENAME', '--filename=FILENAME', 'The base filename for repos') do |filename|
-        org.base_filename = filename
-      end
-      opt.on('-pPREFIX', '--prefix=PREFIX', 'Semester prefix, eg fa23.') do |pfx|
-        org.semester = pfx
-      end
-      opt.on('-tTEMPLATE', '--template=TEMPLATE', 'The repo name within the org to use as template') do |template|
-        org.template = template
-      end
-      opt.on('-sSTUDENTTEAM', '--studentteam=STUDENTTEAM', 'The team name of all the students team') do |studentteam|
-        org.parentteam = studentteam
-      end
-      opt.on('-gGSITEAM', '--gsiteam=GSITEAM', 'The team name of all the staff team') do |gsiteam|
-        org.gsiteam = gsiteam
-      end
-      opt.on('-oORGNAME', '--orgname=ORGNAME', 'The name of the org') do |orgname|
-        org.orgname = orgname
-      end
-    when 'remove_indiv_repos'
-      opt.on('-pPREFIX', '--prefix=PREFIX', 'Semester prefix, eg fa23.') do |pfx|
-        org.semester = pfx
-      end
-      opt.on('-fFILENAME', '--filename=FILENAME', 'The base filename for repos') do |filename|
-        org.base_filename = filename
-      end
-      opt.on('-oORGNAME', '--orgname=ORGNAME', 'The name of the org') do |orgname|
-        org.orgname = orgname
-      end
-    when 'remove_team_repos'
-      opt.on('-pPREFIX', '--prefix=PREFIX', 'Semester prefix, eg fa23.') do |pfx|
-        org.semester = pfx
-      end
-      opt.on('-fFILENAME', '--filename=FILENAME', 'The base filename for repos') do |filename|
-        org.base_filename = filename
-      end
-      opt.on('-oORGNAME', '--orgname=ORGNAME', 'The name of the org') do |orgname|
-        org.orgname = orgname
-      end
-    when 'remove_teams'
-      opt.on('-pPREFIX', '--prefix=PREFIX', 'Semester prefix, eg fa23.') do |pfx|
-        org.semester = pfx
-      end
-      opt.on('-sSTUDENTTEAM', '--studentteam=STUDENTTEAM', 'The team name of all the students team') do |studentteam|
-        org.parentteam = studentteam
-      end
-      opt.on('-oORGNAME', '--orgname=ORGNAME', 'The name of the org') do |orgname|
-        org.orgname = orgname
-      end
-    when 'remove_team_repo_access'
-      opt.on('-fFILENAME', '--filename=FILENAME', 'The base filename for repos') do |filename|
-        org.base_filename = filename
-      end
-      opt.on('-pPREFIX', '--prefix=PREFIX', 'Semester prefix, eg fa23.') do |pfx|
-        org.semester = pfx
-      end
-      opt.on('-oORGNAME', '--orgname=ORGNAME', 'The name of the org') do |orgname|
-        org.orgname = orgname
-      end
+    opt.on('-cCSVFILE', '--csv=CSVFILE', 'CSV file containing at leaset "Email" named columns') do |csv|
+      org.csv = csv
+    end
+    opt.on('-oORGNAME', '--orgname=ORGNAME', 'The name of the org') do |orgname|
+      org.orgname = orgname
+    end
+    opt.on('-sSTUDENTTEAM', '--studentteam=STUDENTTEAM', 'The team name of all the students team') do |studentteam|
+      org.parentteam = studentteam
+    end
+    opt.on('-pPREFIX', '--prefix=PREFIX', 'Semester prefix, eg fa23.') do |pfx|
+      org.semester = pfx
+    end
+    opt.on('-fFILENAME', '--filename=FILENAME', 'The base filename for repos') do |filename|
+      org.base_filename = filename
+    end
+    opt.on('-tTEMPLATE', '--template=TEMPLATE', 'The repo name within the org to use as template') do |template|
+      org.template = template
+    end
+    opt.on('-gGSITEAM', '--gsiteam=GSITEAM', 'The team name of all the staff team') do |gsiteam|
+      org.gsiteam = gsiteam
     end
   end
   $opts.parse!
@@ -167,7 +81,7 @@ class OrgManager
     @users = []
     @childteams = Hash.new { |hash, key| hash[key] = [] } # teamID => [email1, email2, ...]
     print_error("GITHUB_ORG_API_KEY not defined in environment") unless (@key = ENV['GITHUB_ORG_API_KEY'])
-    @client = Octokit::Client.new(access_token: @key)
+    @client = Octokit::Client.new(access_token: @key, scopes: ['user', 'user:email'])
   end
 
   private
@@ -193,6 +107,23 @@ class OrgManager
     end
   end
 
+def to_slug(input)
+  # Convert to lowercase
+  slug = input.downcase
+
+  # Replace characters other than 0-9, a-z, '.', '_', and '-'
+  slug.gsub!(/[^0-9a-z.\-_]+/, '-')
+
+  # Remove leading and trailing hyphens
+  slug.gsub!(/^-+/, '')
+  slug.gsub!(/-+$/, '')
+
+  # Limit the string to 63 characters
+  slug = slug[0, 63]
+
+  return slug
+end
+
   def invite_valid?
     if @orgname.nil? || @orgname.empty? || @csv.nil? || @parentteam.nil? || @parentteam.empty?
       return false
@@ -215,7 +146,7 @@ class OrgManager
   end
 
   def repos_valid?
-    !(@orgname.nil? || @parentteam.nil? || @prefix.nil? || @template.nil? || gsiteam_valid? || @base_filename.nil?)
+    !(@orgname.nil? || @parentteam.nil? || @semester.nil? || @template.nil? || !gsiteam_valid? || @base_filename.nil?)
   end
 
   def remove_valid?
@@ -230,7 +161,7 @@ class OrgManager
     gsiteam_obj = nil
     if !@gsiteam.nil? && @gsiteam.length > 0 
       begin
-        gsiteam_obj = @client.team_by_name(@orgname, @gsiteam)
+        gsiteam_obj = @client.team_by_name(@orgname, to_slug(@gsiteam))
       rescue Octokit::NotFound
         print_error "Can't find the gsi team in the org."
       end
@@ -257,13 +188,13 @@ class OrgManager
 
       # Looking for the STUDENTTEAM in the org, see if it is exist.
       begin
-        parentteam_id = @client.team_by_name(@orgname, @parentteam)['id']
+        parentteam_id = @client.team_by_name(@orgname, to_slug(@parentteam))['id']
       rescue Octokit::NotFound
         parentteam_id = @client.create_team(@orgname, {name: @parentteam, privacy: 'closed'})['id']
       end
 
       @users.each do |student_email|
-        if !@client.team_invitations(parentteam_id).any? {|invitations| invitations.email == member}
+        if !@client.team_invitations(parentteam_id).any? {|invitations| invitations.email == student_email}
           # invitation is not pending, send invitation
           begin
             @client.post(%Q{/orgs/#{@orgname}/invitations}, {org: @orgname, email: student_email , role: 'direct_member', team_ids: [parentteam_id]})
@@ -278,7 +209,7 @@ class OrgManager
       
       # Looking for the STUDENTTEAM in the org, see if it is exist.
       begin
-        parentteam_id = @client.team_by_name(@orgname, @parentteam)['id']
+        parentteam_id = @client.team_by_name(@orgname, to_slug(@parentteam))['id']
       rescue Octokit::NotFound
         parentteam_id = @client.create_team(@orgname, {name: @parentteam, privacy: 'closed'})['id']
       end
@@ -288,7 +219,7 @@ class OrgManager
       @childteams.each_key do |team|
         childteam_name = %Q{#{@semester}-#{team}}
         begin
-          childteam = @client.team_by_name(@orgname, childteam_name)
+          childteam = @client.team_by_name(@orgname, to_slug(childteam_name))
         rescue Octokit::NotFound
           childteam = @client.create_team(@orgname, {name: %Q{#{@semester}-#{team}}, parent_team_id: parentteam_id})
         end
@@ -315,16 +246,23 @@ class OrgManager
 
     # Looking for the STUDENTTEAM in the org, see if it is exist.
     begin
-      parentteam_id = @client.team_by_name(@orgname, @parentteam)['id']
+      parentteam_id = @client.team_by_name(@orgname, to_slug(@parentteam))['id']
     rescue Octokit::NotFound
       print_error "Please make sure the invite command runs first, or students team is created."
     end
 
     email_to_username_map = {}
 
-    @client.team_members(parent_team_id).each do |mem|
-      email_to_username_map[mem.login] = mem.email
+    @client.team_members(parentteam_id).each do |mem|
+      team_mem = @client.user
+      puts team_mem.login
     end
+
+    @client.team_members(parentteam_id).each do |mem|
+      email_to_username_map[mem.email] = mem.login
+    end
+
+    puts email_to_username_map
 
     failed_emails = []
 
@@ -332,8 +270,7 @@ class OrgManager
     @childteams.each_key do |team|
       childteam_name = %Q{#{@semester}-#{team}}
       begin
-        childteam = @client.team_by_name(@orgname, childteam_name)
-        print_error "Childteam has been created before the script runs."
+        childteam = @client.team_by_name(@orgname, to_slug(childteam_name))
       rescue Octokit::NotFound
         childteam = @client.create_team(@orgname, {name: %Q{#{@semester}-#{team}}, parent_team_id: parentteam_id})
       end
@@ -360,22 +297,44 @@ class OrgManager
     
     # Looking for the STUDENTTEAM in the org, see if it is exist.
     begin
-      parentteam_id = @client.team_by_name(@orgname, @parentteam)['id']
+      parentteam_id = @client.team_by_name(@orgname, to_slug(@parentteam))['id']
     rescue Octokit::NotFound
       print_error "Please make sure students team is created."
     end
 
-    @client.team_members(parent_team_id).each do |mem|
-      new_repo_name = %Q{#{@semester}-#{mem.login}-#{@base_filename}}
-      if !@client.repository? %Q{#{@orgname}/#{new_repo_name}}
-        begin
-          new_repo = @client.create_repository_from_template(%Q{#{@orgname}/#{@template}}, new_repo_name, 
-            {owner: @orgname, private: true})
-        rescue Octokit::NotFound
-          print_error "Template not found."
+    gsiteam_id =  @client.team_by_name(@orgname, to_slug(@gsiteam)).id
+    self_user_name = @client.user.login
+    @client.team_members(parentteam_id).each do |mem|
+      if self_user_name != mem.login
+        new_repo_name = %Q{#{@semester}-#{mem.login}-#{@base_filename}}
+        if !@client.repository? %Q{#{@orgname}/#{new_repo_name}}
+          begin
+            new_repo = @client.create_repository_from_template(%Q{#{@orgname}/#{@template}}, new_repo_name, 
+              {owner: @orgname, private: true})
+          rescue Octokit::NotFound
+            print_error "Template not found."
+          end
+          @client.add_collab(new_repo['full_name'], mem.login)
+          @client.add_team_repository(gsiteam_id, new_repo['full_name'], {permission: 'admin'})
         end
-        @client.add_collab(new_repo, mem.login)
-        @client.add_team_repository(gsiteam_id, new_repo['full_name'], {permission: 'admin'})
+      end
+    end
+
+
+    # can remove the below loop because in the future, there should not be child teams while we assigning the indiv repos. 
+    @client.child_teams(parentteam_id).each.each do |mem|
+      if !mem.login.nil? && self_user_name != mem.login
+        new_repo_name = %Q{#{@semester}-#{mem.login}-#{@base_filename}}
+        if !@client.repository? %Q{#{@orgname}/#{new_repo_name}}
+          begin
+            new_repo = @client.create_repository_from_template(%Q{#{@orgname}/#{@template}}, new_repo_name, 
+              {owner: @orgname, private: true})
+          rescue Octokit::NotFound
+            print_error "Template not found."
+          end
+          @client.add_collab(new_repo['full_name'], mem.login)
+          @client.add_team_repository(gsiteam_id, new_repo['full_name'], {permission: 'admin'})
+        end
       end
     end
   end
@@ -383,14 +342,11 @@ class OrgManager
   def team_repos
     print_error "orgname, student team name, base filename, template repo name, semester prefix, and gsi team name needed." unless repos_valid?
 
-    @childteams.each_key do |team|
-      begin
-        team_id = @client.team_by_name(@orgname, %Q{#{@semester}-#{team}})['id']
-      rescue Octokit::NotFound
-        print_error "Students teams are not created."
-      end
-      gsiteam_id = @client.team_by_name(@orgname, @gsiteam)['id']
-      new_repo_name = %Q{#{@semester}-#{@base_filename}-#{team}}
+    child_teams = @client.child_teams(@client.team_by_name(@orgname, to_slug(@parentteam)).id)
+    gsiteam_id = @client.team_by_name(@orgname, to_slug(@gsiteam))['id']
+    child_teams.each do |team|
+      team_num = team.slug.match(/-(\d+)$/)[1]
+      new_repo_name = %Q{#{@semester}-#{@base_filename}-#{team_num}}
       if !@client.repository? %Q{#{@orgname}/#{new_repo_name}}
         begin
           new_repo = @client.create_repository_from_template(%Q{#{@orgname}/#{@template}}, new_repo_name, 
@@ -398,7 +354,7 @@ class OrgManager
         rescue Octokit::NotFound
           print_error "Template not found."
         end
-        @client.add_team_repository(team_id, new_repo['full_name'], {permission: 'push'})
+        @client.add_team_repository(team.id, new_repo['full_name'], {permission: 'push'})
         @client.add_team_repository(gsiteam_id, new_repo['full_name'], {permission: 'admin'})
       end
     end
@@ -410,8 +366,8 @@ class OrgManager
 
     repos = @client.org_repos(@orgname, {:type => 'private'})
     repos.each do |repo|
-      if repo.name =~ /^#{Regexp.escape(@orgname)}\/#{Regexp.escape(@semester)}-(.*)-#{Regexp.escape(@base_filename)}$/
-        @client.delete_repository(repo)
+      if repo.name =~ /^#{Regexp.escape(@semester)}-(.*)-#{Regexp.escape(@base_filename)}$/
+        @client.delete_repository(repo.full_name)
       end
     end
   end
@@ -421,33 +377,35 @@ class OrgManager
 
     repos = @client.org_repos(@orgname, {:type => 'private'})
     repos.each do |repo|
-      if repo.name =~ /^#{Regexp.escape(@orgname)}\/#{Regexp.escape(@semester)}-#{Regexp.escape(@base_filename)}-\d+$/
-        @client.delete_repository(repo)
+      if repo.name =~ /^#{Regexp.escape(@semester)}-#{Regexp.escape(@base_filename)}-\d+$/
+        @client.delete_repository(repo.full_name)
       end
     end
   end
 
   def remove_teams
-    print_error "org name, semester prefix, students team namd are needed." unless remove_teams_valid?
+    print_error "org name, semester prefix, students team name are needed." unless remove_teams_valid?
 
     # Looking for the STUDENTTEAM in the org, see if it is exist.
     begin
-      parentteam_id = @client.team_by_name(@orgname, @parentteam)['id']
+      parentteam_id = @client.team_by_name(@orgname, to_slug(@parentteam))['id']
     rescue Octokit::NotFound
       print_error "Please make sure students team is created."
     end
-    
-    # # Remove all child teams
-    # @client.org_teams(@orgname).each do |team|
-    #   if team.parent.id == parentteam_id
-    #     @client.delete_team team.id
-    #   end
-    # end
 
     # Remove all members in the students team from org
-    @client.team_members(parent_team_id).each do |mem|
-      if @client.organization_membership(@orgname, :user => mem.login)['role'] == 'member'
+    self_user_name = @client.user.login
+    @client.team_members(parentteam_id).each do |mem|
+      if !mem.login.nil? && mem.login != self_user_name
         @client.remove_organization_member(@orgname, mem.login)
+      end 
+    end
+
+    @client.child_teams(parentteam_id).each do |childteam|
+      @client.team_members(childteam.id).each do |mem|
+        if !mem.login.nil? && mem.login != self_user_name
+          @client.remove_organization_member(@orgname, mem.login)
+        end
       end
     end
 
@@ -460,11 +418,11 @@ class OrgManager
 
     repos = @client.org_repos(@orgname, {:type => 'private'})
     repos.each do |repo|
-      match = repo.name.match(/^#{Regexp.escape(@orgname)}\/#{Regexp.escape(@semester)}-#{Regexp.escape(@base_filename)}-(\d+)$/)
+      match = repo.name.match(/^#{Regexp.escape(@semester)}-#{Regexp.escape(@base_filename)}-(\d+)$/)
       if match
         team_num = match[1]
         begin
-          childteam_id = @client.team_by_name(@orgname, %Q{#{@semester}-#{team_num}})['id'] # eg slug fa23-1
+          childteam_id = @client.team_by_name(@orgname, to_slug(%Q{#{@semester}-#{team_num}}))['id'] # eg slug fa23-1
         rescue Octokit::NotFound
           next
         end

--- a/scripts/github-repos/github-repos.rb
+++ b/scripts/github-repos/github-repos.rb
@@ -299,18 +299,20 @@ end
 
 
     # can remove the below loop because in the future, there should not be child teams while we assigning the indiv repos. 
-    @client.child_teams(parentteam_id).each.each do |mem|
-      if !mem.login.nil? && self_user_name != mem.login
-        new_repo_name = %Q{#{@semester}-#{mem.login}-#{@base_filename}}
-        if !@client.repository? %Q{#{@orgname}/#{new_repo_name}}
-          begin
-            new_repo = @client.create_repository_from_template(%Q{#{@orgname}/#{@template}}, new_repo_name, 
-              {owner: @orgname, private: true})
-          rescue Octokit::NotFound
-            print_error "Template not found."
+    @client.child_teams(parentteam_id).each do |childteam|
+      @client.team_members(childteam.id).each do |mem|
+        if !mem.login.nil? && self_user_name != mem.login
+          new_repo_name = %Q{#{@semester}-#{mem.login}-#{@base_filename}}
+          if !@client.repository? %Q{#{@orgname}/#{new_repo_name}}
+            begin
+              new_repo = @client.create_repository_from_template(%Q{#{@orgname}/#{@template}}, new_repo_name, 
+                {owner: @orgname, private: true})
+            rescue Octokit::NotFound
+              print_error "Template not found."
+            end
+            @client.add_collab(new_repo['full_name'], mem.login)
+            @client.add_team_repository(gsiteam_id, new_repo['full_name'], {permission: 'admin'})
           end
-          @client.add_collab(new_repo['full_name'], mem.login)
-          @client.add_team_repository(gsiteam_id, new_repo['full_name'], {permission: 'admin'})
         end
       end
     end

--- a/scripts/github-repos/team-test.csv
+++ b/scripts/github-repos/team-test.csv
@@ -1,3 +1,3 @@
-Team,Email,Name
-1,609847732amy@gmail.com,Amy
-2,ghu@berkeley.edu,colin
+Team,Username,Name
+1,KCsama,Amy
+2,Gangster-Who,Gang hu

--- a/scripts/github-repos/team-test.csv
+++ b/scripts/github-repos/team-test.csv
@@ -1,3 +1,0 @@
-Team,Username,Name
-1,KCsama,Amy
-2,Gangster-Who,Gang hu

--- a/scripts/github-repos/team-test.csv
+++ b/scripts/github-repos/team-test.csv
@@ -1,0 +1,3 @@
+Team,Email/Username,Name
+1,ydong19@berkeley.edu,Amy
+2,

--- a/scripts/github-repos/team-test.csv
+++ b/scripts/github-repos/team-test.csv
@@ -1,3 +1,3 @@
-Team,Email/Username,Name
-1,ydong19@berkeley.edu,Amy
-2,
+Team,Email,Name
+1,609847732amy@gmail.com,Amy
+2,ghu@berkeley.edu,colin


### PR DESCRIPTION
 GitHub Script modifications:
For each individually-submitted assignment
Make 1 repo per student, which starts from the public template
fa23-[username]-chips-[number] (can create by using PREFIX-[username]-FILENAME)
Each repo has only 1 collaborator.

Username is the prefix to the berkeley.edu email address (e.g. “ball” for “ball@berkeley.edu”)
Github API doesn't provide adding collaborator using emails, and it also doesn't provide a way to get Github users emails.
Students also have emails other than berkeley email associated with Github account. Therefore, it is difficult to create repos and add students as collaborator to the repos using berkeley emails. 
In this script, it will create repos using **Github name** for students in the students team. (Whether students are in the child teams for 10.5)
