### PR TITLE
[fix] Allow Heroku CLI >= 8 to Pass Verification Script

### DIFF
--- a/verify-setup.sh
+++ b/verify-setup.sh
@@ -90,7 +90,7 @@ check_heroku() {
     ## is Heroku CLI installed?
     source $HOME/.rvm/scripts/rvm
     echo -n "Checking for Heroku CLI..."
-    if [[ `rvm use ; heroku --version` = *'heroku/7'* ]]; then
+    if [[ $(heroku --version | sed 's/heroku\/\([[:digit:]]\).*/\1/') -ge 7 ]]; then
         echo "OK"
     else
         quit "Heroku CLI >=7.0.0 is not installed. See devcenter.heroku.com/articles/heroku-cli"

--- a/verify-setup.sh
+++ b/verify-setup.sh
@@ -90,7 +90,7 @@ check_heroku() {
     ## is Heroku CLI installed?
     source $HOME/.rvm/scripts/rvm
     echo -n "Checking for Heroku CLI..."
-    if [[ $(heroku --version | sed 's/heroku\/\([[:digit:]]\).*/\1/') -ge 7 ]]; then
+    if [[ $(heroku --version | grep -oP 'heroku/\K\d+') -ge 7 ]]; then
         echo "OK"
     else
         quit "Heroku CLI >=7.0.0 is not installed. See devcenter.heroku.com/articles/heroku-cli"

--- a/verify-setup.sh
+++ b/verify-setup.sh
@@ -90,7 +90,7 @@ check_heroku() {
     ## is Heroku CLI installed?
     source $HOME/.rvm/scripts/rvm
     echo -n "Checking for Heroku CLI..."
-    if [[ $(heroku --version | grep -oP 'heroku/\K\d+') -ge 7 ]]; then
+    if [[ $(heroku --version | sed 's/heroku\/\([[:digit:]]\).*/\1/') -ge 7 ]]; then
         echo "OK"
     else
         quit "Heroku CLI >=7.0.0 is not installed. See devcenter.heroku.com/articles/heroku-cli"


### PR DESCRIPTION
# Description

Right now, the test script ensures that the user is running Heroku CLI ~> 7 which is not consistent with what the comment and error output say:
> Heroku CLI >=7.0.0 is not installed. See devcenter.heroku.com/articles/heroku-cli

As such, we want to check that the Heroku CLI is >= 7.

# Changes

Instead of using pure regex string match to check for a specific version, I used `sed` to extract out just the major version and test using the respective inequality to 7.

# Testing

I tested both success and failure branches on my local setup, but without the configuration of a runner of some sort, I'm not familiar with a good way to test scripts.